### PR TITLE
fix: Update Flutter version in workflow to 3.32.2 to support Dart SDK ^3.7.2

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.24.0" # Specify your Flutter version
+          flutter-version: "3.32.2" # Updated to support Dart SDK ^3.7.2
           channel: "stable"
 
       - name: Extract version from tag


### PR DESCRIPTION
This pull request updates the Flutter version in the Android release workflow to ensure compatibility with the latest Dart SDK.

* [`.github/workflows/android_release.yml`](diffhunk://#diff-a801b9609825f4b567c4afd40459e85e5c5f54eba16a62f6bda2c7925819be2aL26-R26): Updated the `flutter-version` from `3.24.0` to `3.32.2` in the `Set up Flutter` step to support Dart SDK version `^3.7.2`.